### PR TITLE
Fix csharp_prefer_simple_default_expression setting.

### DIFF
--- a/EditorConfigGenerator.Core.Tests/Styles/CSharpPreferSimpleDefaultExpressionStyleTests.cs
+++ b/EditorConfigGenerator.Core.Tests/Styles/CSharpPreferSimpleDefaultExpressionStyleTests.cs
@@ -160,5 +160,26 @@ namespace EditorConfigGenerator.Core.Tests.Styles
 			Assert.That(data.TrueOccurences, Is.EqualTo(0u), nameof(data.TrueOccurences));
 			Assert.That(data.FalseOccurences, Is.EqualTo(0u), nameof(data.FalseOccurences));
 		}
+
+		[Test]
+		public static void UpdateWithStringLiteral()
+		{
+			var style = new CSharpPreferSimpleDefaultExpressionStyle(new BooleanData(default, default, default));
+			var statement = (ExpressionSyntax)SyntaxFactory.ParseCompilationUnit(
+@"public class Foo
+{
+	public void Bar()
+	{
+		string x = ""Hello World"";
+	}
+}", options: Shared.ParseOptions).DescendantNodes().Single(_ => _.Kind() == SyntaxKind.StringLiteralExpression);
+			var newStyle = style.Update(statement);
+
+			var data = newStyle.Data;
+			Assert.That(newStyle, Is.Not.SameAs(style), nameof(newStyle));
+			Assert.That(data.TotalOccurences, Is.EqualTo(0u), nameof(data.TotalOccurences));
+			Assert.That(data.TrueOccurences, Is.EqualTo(0u), nameof(data.TrueOccurences));
+			Assert.That(data.FalseOccurences, Is.EqualTo(0u), nameof(data.FalseOccurences));
+		}
 	}
 }

--- a/EditorConfigGenerator.Core/Styles/CSharpPreferSimpleDefaultExpressionStyle.cs
+++ b/EditorConfigGenerator.Core/Styles/CSharpPreferSimpleDefaultExpressionStyle.cs
@@ -1,4 +1,5 @@
 ﻿using EditorConfigGenerator.Core.Statistics;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System;
 using static EditorConfigGenerator.Core.Extensions.EnumExtensions;
@@ -40,7 +41,7 @@ namespace EditorConfigGenerator.Core.Styles
 
 			if (!node.ContainsDiagnostics)
 			{
-				if (node is LiteralExpressionSyntax)
+				if (node is LiteralExpressionSyntax && node.Kind() == SyntaxKind.DefaultLiteralExpression)
 				{
 					return new CSharpPreferSimpleDefaultExpressionStyle(this.Data.Update(true), this.Severity);
 				}


### PR DESCRIPTION
We noticed that the setting csharp_prefer_simple_default_expression is generated when there is a string literal in the code. This pull request is to fix this.

The following test cases have been validated:

- a string literal, expected: nothing shows up
`Console.WriteLine("Hello World!");`
- a default literal, expected: csharp_prefer_simple_default_expression = true
`int i = default`
- default operator with argument, expected: csharp_prefer_simple_default_expression = false
`int i = default(int)`
- a default operator and multiple default literal, expected: csharp_prefer_simple_default_expression = true
`int i = default;
int j = default;
int a = default(int)`